### PR TITLE
Classifierresultshotfix

### DIFF
--- a/src/main/java/evaluation/ClassifierResultsAnalysis.java
+++ b/src/main/java/evaluation/ClassifierResultsAnalysis.java
@@ -200,9 +200,15 @@ public class ClassifierResultsAnalysis {
                     + "CONTINUING THE ANALYSIS FOR NOW, but ignoring the timings");
         }
         
+        //TODO clean all of this timing stuff up, it's jsut another layer of hacky nonsense. 
+        //just need a CLEAN break of 'does everything have timings? do all the timing analysis. 
+        //does ANYTHING not have timings? do NONE of the timing analysis
+        
         //using the presence of summaries for train and test timings as an indicator that they are present 
-        List<PerformanceMetric> timeMetrics = Arrays.asList(PerformanceMetric.buildTime, testTimeMetric); //PerformanceMetric.totalTestTime, PerformanceMetric.avgTestPredTime
-        for (int j = 0; j < trainTestTimingSummary.length; j++) {
+        List<PerformanceMetric> timeMetrics = new ArrayList<>();
+        timeMetrics.add(PerformanceMetric.buildTime);
+        timeMetrics.add(testTimeMetric); //PerformanceMetric.totalTestTime, PerformanceMetric.avgTestPredTime
+        for (int j = trainTestTimingSummary.length-1; j >= 0; j--) {
             String label = timeMetrics.get(j).name;
             if (trainTestTimingSummary[j] != null) {
                 //present, so add on automatically to the list of metrics for passing around to spreadsheet/image makers etc

--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -1432,7 +1432,7 @@ public class ClassifierResults implements DebugPrinting, Serializable{
                 double eps = 1.e-8;
                 if (Math.abs(reportedTestAcc - acc) > eps) {
                     throw new ArithmeticException("Calculated accuracy (" + acc + ") differs from written accuracy (" + reportedTestAcc + ") "
-                            + "by more than eps (" + eps + ")");
+                            + "by more than eps (" + eps + "). File = " + path + ". numinstances = " + numInstances + ". numClasses = " + numClasses);
                 }
                 break;
             }

--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -780,7 +780,7 @@ public class ClassifierResults implements DebugPrinting, Serializable{
      * 
      * The description argument may be null, however all other arguments are required in full
      * 
-     * Todo future, maaaybe add enum for tie resolution to handle it here.
+     * Todo future, maaaybe add enum/functor arg for tie resolution to handle it here.
      *
      * The true class is missing, however can be added in one go later with the 
      * method finaliseResults(double[] trueClassVals)
@@ -1046,6 +1046,8 @@ public class ClassifierResults implements DebugPrinting, Serializable{
         return exists(new File(path));
     }
     
+    private boolean firstTimeDistMissing = true;
+    public static boolean printDistMissingWarning = true;
     /**
      * Reads and STORES the prediction in this classifierresults object
      * returns true if the prediction described by this string was correct (i.e. truclass==predclass) 
@@ -1063,11 +1065,25 @@ public class ClassifierResults implements DebugPrinting, Serializable{
         double trueClassVal=Double.valueOf(split[0].trim());
         double predClassVal=Double.valueOf(split[1].trim());
         
-        if(split.length==2) //no probabilities, no timing. VERY old files will not have them
-            return true;
-        
+        if(split.length<3) { //no probabilities, no timing. VERY old files will not have them
+            if (printDistMissingWarning && firstTimeDistMissing) {
+                System.out.println("*********");
+                System.out.println("");
+                System.out.println("Probability distribution information missing in file. Be aware that certain stats cannot be computed, usability will be diminished. "
+                        + "If you know this and dont want this message being printed right now, since e.g. it's messing up your "
+                        + "own print formatting, set ClassifierResults.printDistMissingWarning to false.");
+                System.out.println("");
+                System.out.println("*********");
+
+                firstTimeDistMissing = false;
+            }
+            
+            addPrediction(trueClassVal, null, predClassVal, -1, "");
+            return trueClassVal==predClassVal;
+        }
+        //else 
         //collect probabilities
-        int distStartInd = 3; //actual, predicted, space, distStart
+        final int distStartInd = 3; //actual, predicted, space, distStart
         double[] dist = null;
         if (numClasses < 2) {
             List<Double> distL = new ArrayList<>();
@@ -1097,13 +1113,13 @@ public class ClassifierResults implements DebugPrinting, Serializable{
         
         //collect timings
         long predTime = -1;
-        int timingInd = distStartInd + (numClasses-1) + 1 + 1; //actual, predicted, space, dist, space, timing
+        final int timingInd = distStartInd + (numClasses-1) + 1 + 1; //actual, predicted, space, dist, space, timing
         if (split.length > timingInd)
             predTime = Long.parseLong(split[timingInd].trim());
         
         //collect description
         String description = "";
-        int descriptionInd = timingInd + 1 + 1; //actual, predicted, space, dist, space, timing, space, description
+        final int descriptionInd = timingInd + 1 + 1; //actual, predicted, space, dist, space, timing, space, description
         if (split.length > descriptionInd) {
             description = split[descriptionInd];
             
@@ -1434,6 +1450,12 @@ public class ClassifierResults implements DebugPrinting, Serializable{
                     throw new ArithmeticException("Calculated accuracy (" + acc + ") differs from written accuracy (" + reportedTestAcc + ") "
                             + "by more than eps (" + eps + "). File = " + path + ". numinstances = " + numInstances + ". numClasses = " + numClasses);
                 }
+                
+                if (predDistributions == null || predDistributions.isEmpty() || predDistributions.get(0) == null) {
+                    if (printDistMissingWarning)
+                        System.out.println("Probabiltiy distributions missing from file: " + path);
+                }
+                
                 break;
             }
             case METRICS:
@@ -1474,32 +1496,36 @@ public class ClassifierResults implements DebugPrinting, Serializable{
      * of added predictions)
      */   
     public void findAllStats(){
-       if (numInstances <= 0)
-           inferNumInstances();
-       if (numClasses <= 0)
-           inferNumClasses();
         
-       confusionMatrix=buildConfusionMatrix();
-       
-       countPerClass=new double[confusionMatrix.length];
-       for(int i=0;i<trueClassValues.size();i++)
-           countPerClass[trueClassValues.get(i).intValue()]++;
-       
-       acc=0;
-       for(int i=0;i<numClasses;i++)
-           acc+=confusionMatrix[i][i];
-       acc/=numInstances;
-       
-       balancedAcc=findBalancedAcc(confusionMatrix);
-       nll=findNLL();
-       meanAUROC=findMeanAUROC();
-       mcc = computeMCC(confusionMatrix);
-       
-       f1=findF1(confusionMatrix); //also handles spec/sens/prec/recall in the process of finding f1
-       
-       medianPredTime=findMedianPredTime();
-       
-       allStatsFound = true;
+        //meta info
+        if (numInstances <= 0)
+            inferNumInstances();
+        if (numClasses <= 0)
+            inferNumClasses();
+        
+        //predictions-only 
+        confusionMatrix=buildConfusionMatrix();
+
+        countPerClass=new double[confusionMatrix.length];
+        for(int i=0;i<trueClassValues.size();i++)
+            countPerClass[trueClassValues.get(i).intValue()]++;
+
+        calculateAcc();
+        balancedAcc=findBalancedAcc(confusionMatrix);
+        
+        mcc = computeMCC(confusionMatrix);
+        f1=findF1(confusionMatrix); //also handles spec/sens/prec/recall in the process of finding f1
+
+        //need probabilities. very old files that have been read in may not have them.
+        if (predDistributions != null && !predDistributions.isEmpty() && predDistributions.get(0) != null ) {
+            nll=findNLL();
+            meanAUROC=findMeanAUROC();
+        }
+
+        //timing 
+        medianPredTime=findMedianPredTime();
+
+        allStatsFound = true;
     }
    
     


### PR DESCRIPTION
Allowing very old files with no probabilities, some basic work arounds within classifierresults to handle that. Stuff outside has to be aware that the distributions list or each distribution may be null/empty

Also another band-aid for timings in eval code when some results have timings and some dont