### PR TITLE
Cawpehotfix

### DIFF
--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -49,8 +49,9 @@ import utilities.InstanceTools;
  *    - get/setClassifierName(String)
  *    - get/setSplit(String)
  *    - get/setFoldId(String)
- *    - get/setDescription(String)
  *    - get/setTimeUnit(TimeUnit)
+ *    - FileType, set implicitly via the write...() method used 
+ *    - get/setDescription(String)
  *  [LINE 2 OF FILE]
  *    - get/setParas(String)
  *  [LINE 3 OF FILE]
@@ -59,6 +60,7 @@ import utilities.InstanceTools;
  *    - get/setTestTime(long)
  *    - get/setBenchmarkTime(long)
  *    - get/setMemory(long)
+ *    - (set)numClasses(int) (either set by user or indirectly found through predicted probability distributions)
  *  [REMAINING LINES: PREDICTIONS]
  *    - trueClassVal, predClassVal,[empty], dist[0], dist[1] ... dist[c],[empty], predTime, [empty], predDescription
  * 
@@ -1392,6 +1394,8 @@ public class ClassifierResults implements DebugPrinting, Serializable{
             benchmarkTime = Long.parseLong(parts[3]);
         if (parts.length > 4) 
             memoryUsage = Long.parseLong(parts[4]);
+        if (parts.length > 5) 
+            numClasses = Integer.parseInt(parts[5]);
         
         return acc;
     }
@@ -1400,7 +1404,8 @@ public class ClassifierResults implements DebugPrinting, Serializable{
             + "," + buildTime
             + "," + testTime
             + "," + benchmarkTime
-            + "," + memoryUsage;
+            + "," + memoryUsage
+            + "," + numClasses();
         return res;
     }
 

--- a/src/main/java/vector_classifiers/CAWPE.java
+++ b/src/main/java/vector_classifiers/CAWPE.java
@@ -525,8 +525,11 @@ public class CAWPE extends AbstractClassifier implements HiveCoteModule, SavePar
         else
             trainModules();
 
-        for (int m = 0; m < modules.length; m++)
+        for (int m = 0; m < modules.length; m++) { 
+            //in case train results didnt have probability distributions, hack for old hive cote results tony todo clean
+            modules[m].trainResults.setNumClasses(trainInsts.numClasses());
             modules[m].trainResults.findAllStatsOnce();
+        }
     }
 
     protected boolean willNeedToDoCV() {


### PR DESCRIPTION
number of classes now being written explicitly to file, instead of left to being inferred via probability distributions in case they dont exist (though they always should.)

added an explicit setting of the number of classes to cawpe after readings in members as well to cover the same case 